### PR TITLE
Fixed flaky test in SvgGraphics2DTest

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -546,6 +546,12 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-xml</artifactId>
+            <version>2.13.5</version>
+            <scope>test</scope>
+        </dependency>
 
     </dependencies>
 

--- a/core/src/test/java/org/apache/hop/core/svg/HopSvgGraphics2DTest.java
+++ b/core/src/test/java/org/apache/hop/core/svg/HopSvgGraphics2DTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.hop.core.svg;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import org.apache.commons.lang.SystemUtils;
 import org.junit.Before;
 import org.junit.Test;
@@ -57,7 +59,10 @@ public class HopSvgGraphics2DTest {
   @Test
   public void testNewDocumentXml() throws Exception {
     HopSvgGraphics2D graphics2D = HopSvgGraphics2D.newDocument();
-    assertEquals(BASIC_SVG_XML, graphics2D.toXml());
+    XmlMapper xmlMapper = new XmlMapper();
+    JsonNode graphic2DNode = xmlMapper.readTree(graphics2D.toXml());
+    JsonNode basicSVGNode = xmlMapper.readTree(BASIC_SVG_XML);
+    assertEquals(basicSVGNode, graphic2DNode);
   }
 
   @Test
@@ -66,6 +71,9 @@ public class HopSvgGraphics2DTest {
 
     graphics2D.drawOval(50, 50, 25, 25);
 
-    assertEquals(BASIC_CIRCLE_XML, graphics2D.toXml());
+    XmlMapper xmlMapper = new XmlMapper();
+    JsonNode graphic2DNode = xmlMapper.readTree(graphics2D.toXml());
+    JsonNode basicSVGNode = xmlMapper.readTree(BASIC_CIRCLE_XML);
+    assertEquals(basicSVGNode, graphic2DNode);
   }
 }


### PR DESCRIPTION
### Issue
The issue is that in test `org.apache.hop.core.svg.HopSvgGraphics2DTest#testNewDocumentXml`
 and  `org.apache.hop.core.svg.HopSvgGraphics2DTest#testNewDocumentSimpleXml`, inside `graphics2D.toXml`, ` org.apache.batik.svggen.SVGGraphics2D.getRoot`, which uses a `HashMap` iterator to generate the DOM, is called. Since the order of HashMap is unpredictable, the order in generated xml string is nondeterministic. 

## Fix
This flaky test has been fixed through leveraging the Jackson library, which incorporates the JsonNode and XmlParser classes. These components are employed for parsing two XML strings into tree models, which are subsequently compared node by node when assertion is called. 

I understand this fix introduces a new dependency. If prefered, I'm happy to come up with a fix without `com.fasterxml.jackson.dataformat.xml.XmlMapper`.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:
- [x] Run `mvn clean install apache-rat:check` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
- [x] If you have a group of commits related to the same change, please squash your commits into one and force push your branch using `git rebase -i`.
- [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable.

To make clear that you license your contribution under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
