### PR TITLE
Fixed flaky test

### DIFF
--- a/plugins/transforms/propertyinput/src/test/java/org/apache/hop/pipeline/transforms/propertyinput/BaseParsingTest.java
+++ b/plugins/transforms/propertyinput/src/test/java/org/apache/hop/pipeline/transforms/propertyinput/BaseParsingTest.java
@@ -146,6 +146,8 @@ public abstract class BaseParsingTest<
    *     1"}, { "field 1 value in row 2","field 2 value in row 2"} }
    */
   protected void checkContent(Object[][] expected) throws Exception {
+    rows.sort((o1, o2) -> Arrays.toString(o1).compareTo(Arrays.toString(o2)));
+    Arrays.sort(expected, (o1, o2) -> Arrays.toString(o1).compareTo(Arrays.toString(o2)));
     for (int i = 0; i < expected.length; i++) {
       assertArrayEquals("Wrong row: " + Arrays.asList(rows.get(i)), expected[i], rows.get(i));
     }


### PR DESCRIPTION
### Issue
In the test `org.apache.hop.pipeline.transforms.propertyinput.PropertyInputContentParsingTest#testDefaultOptions`, when `process()` is called, function `openNextFile()` will be called when rows are processed.
https://github.com/wang3820/hop/blob/45df66294437da0a8dbb1d611b34afda48408d3b/plugins/transforms/propertyinput/src/main/java/org/apache/hop/pipeline/transforms/propertyinput/PropertyInput.java#L331
When then rows are processed, `data.properties` is created and the iterator is a iterator on the keyset of `data.properties`, which is a `Hashtable` as `Properties` object extends `Hashtable`.
https://github.com/wang3820/hop/blob/45df66294437da0a8dbb1d611b34afda48408d3b/plugins/transforms/propertyinput/src/main/java/org/apache/hop/pipeline/transforms/propertyinput/PropertyInput.java#L464-L466

Due to the unpredictable order of `Hashtable.keyset()`, which uses `Map`,  the elements contained in `rows` variable could have different orders. They are checked as part of the `checkContent()` function:
https://github.com/wang3820/hop/blob/45df66294437da0a8dbb1d611b34afda48408d3b/plugins/transforms/propertyinput/src/test/java/org/apache/hop/pipeline/transforms/propertyinput/BaseParsingTest.java#L142-L148

In this case, the field to value pair would not be effected but the order of the pairs in `rows` is nondeterministic. 

### Proposed Fix

Sort `rows` and `expected` in `checkContent()` before comparing. 


------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:
- [x] Run `mvn clean install apache-rat:check` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
- [x] If you have a group of commits related to the same change, please squash your commits into one and force push your branch using `git rebase -i`.
- [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable.

To make clear that you license your contribution under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
